### PR TITLE
added overrides for bootstrap to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,5 +5,14 @@
     "bootstrap": "~3.3.0",
     "modernizr": "~2.8.2",
     "jquery": "~1.11.1"
+  },
+  "overrides": {
+    "bootstrap": {
+      "main": [
+        "less/bootstrap.less",
+        "dist/css/bootstrap.css",
+        "dist/js/bootstrap.js"
+      ]
+    }
   }
 }


### PR DESCRIPTION
I noticed that when running "grunt serve" the bootstrap.css file is deleted from the top level index.html file. An issue was reported here a few days ago for what I suspect is the same root cause.

After a bit of searching, I think a good, standard solution is to add an override section to the bower.json file. After this pull request, the bootstrap css file is present in the index.html file as expected and the project looks as expected when running localy.

I hope this helps!

Kind Regards,
James
